### PR TITLE
Separating the build and test jobs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,6 +25,22 @@ jobs:
       run: dotnet build
       working-directory: QuantumSport.API
       
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    
+    - name: Setup .NET 6.0.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      working-directory: QuantumSport.API
+      
     - name: Test
       run: dotnet test
       working-directory: QuantumSport.API/QuantumSport.UnitTests


### PR DESCRIPTION
Separating the **build** and **test** into separate jobs, each containing checkout, setup and restore steps